### PR TITLE
Enable deletion of keys not managed through the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ and calling `update-ssh-keys` at the end.
 
 ## Interface
 
-The roles only takes a `group` variable as argument.
+The roles takes 2 parameters:
+- `exclusive` can be set to `yes` (defaults to `no`) to delete SSH keys
+  that are not present in Ansible;
+- `group` must be set to the name of the user group that is given access.
 
 It assumes the presence of two dicts: `user_groups` and `users`:
 - each group is represented by a key in `user_groups`,

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+exclusive: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     key: "{{ users[item].key }}"
     path: "{{ '/home/core/.ssh/authorized_keys.d/' + item }}"
     manage_dir: no
+    exclusive: exclusive
   when: users[item].key is defined
   with_items: user_groups[group]
 
@@ -15,8 +16,19 @@
     key: "{{ lookup('file', 'files/keys/' + item + '.pub') }}"
     path: "{{ '/home/core/.ssh/authorized_keys.d/' + item }}"
     manage_dir: no
+    exclusive: exclusive
   when: users[item].key is not defined
   with_items: user_groups[group]
+
+- name: Delete unknown keys
+  sudo: False
+  tasks:
+    - shell: ls -1 /home/core/.ssh/authorized_keys.d/
+      register: keys
+    - file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
+      with_items: keys.stdout_lines
+      when: item not in user_groups[group]
+  when: exclusive
 
 - name: Run update-ssh-keys
   sudo: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,13 @@
+- name: Delete unknown keys
+  sudo: False
+  tasks:
+    - shell: ls -1 /home/core/.ssh/authorized_keys.d/
+      register: keys
+    - file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
+      with_items: keys.stdout_lines
+      when: item not in user_groups[group]
+  when: exclusive
+
 - name: Add inline keys for user {{ item }}
   sudo: False
   authorized_key:
@@ -19,16 +29,6 @@
     exclusive: exclusive
   when: users[item].key is not defined
   with_items: user_groups[group]
-
-- name: Delete unknown keys
-  sudo: False
-  tasks:
-    - shell: ls -1 /home/core/.ssh/authorized_keys.d/
-      register: keys
-    - file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
-      with_items: keys.stdout_lines
-      when: item not in user_groups[group]
-  when: exclusive
 
 - name: Run update-ssh-keys
   sudo: False


### PR DESCRIPTION
This would be the natural follow-up to https://github.com/hashbang/admin-tools/issues/9.
