### PR TITLE
Automatically delete non-ansible SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ and calling `update-ssh-keys` at the end.
 
 ## Interface
 
-The roles only takes a `group` variable as argument.
+The roles takes 2 parameters:
+- `exclusive` can be set to `yes` (defaults to `no`) to delete SSH keys
+  that are not present in Ansible;
+- `group` must be set to the name of the user group that is given access.
 
 It assumes the presence of two dicts: `user_groups` and `users`:
 - each group is represented by a key in `user_groups`,

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+exclusive: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,13 @@
+- name: Delete unknown keys
+  become: False
+  tasks:
+    - shell: ls -1 /home/core/.ssh/authorized_keys.d/
+      register: keys
+    - file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
+      with_items: keys.stdout_lines
+      when: item not in user_groups[group]
+  when: "{{ exclusive }}"
+
 - name: Add keys for user {{ item }}
   become: False
   authorized_key:
@@ -5,6 +15,7 @@
     key: "{{ users[item].get('key') or lookup('file', 'files/keys/' + item + '.pub') }}"
     path: "{{ '/home/core/.ssh/authorized_keys.d/' + item }}"
     manage_dir: no
+    exclusive: "{{ exclusive }}"
   with_items: user_groups[group]
 
 - name: Run update-ssh-keys


### PR DESCRIPTION
This requires closing hashbang/admin-tools#9 first, and special care must be taken while first testing.
