### PR TITLE
Bugfix

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: update authorized_keys
+  become: False
+  command: update-ssh-keys -l
+  no_log: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,14 @@
-- name: Delete unknown keys
+- name: List keys
   become: False
-  tasks:
-    - shell: ls -1 /home/core/.ssh/authorized_keys.d/
-      register: keys
-    - file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
-      with_items: keys.stdout_lines
-      when: item not in user_groups[group]
+  shell: ls -1 /home/core/.ssh/authorized_keys.d/
+  register: keys
   when: "{{ exclusive }}"
+  changed_when: False
+
+- name: Delete keys for user {{ item }}
+  file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
+  when: exclusive and item not in user_groups[group]
+  with_items: "{{ keys.stdout_lines }}"
 
 - name: Add keys for user {{ item }}
   become: False
@@ -16,7 +18,7 @@
     path: "{{ '/home/core/.ssh/authorized_keys.d/' + item }}"
     manage_dir: no
     exclusive: "{{ exclusive }}"
-  with_items: user_groups[group]
+  with_items: "{{ user_groups[group] }}"
 
 - name: Run update-ssh-keys
   become: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,8 @@
   file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
   when: exclusive and item not in user_groups[group]
   with_items: "{{ keys.stdout_lines }}"
+  notify:
+    - update authorized_keys
 
 - name: Add keys for user {{ item }}
   become: False
@@ -19,8 +21,5 @@
     manage_dir: no
     exclusive: "{{ exclusive }}"
   with_items: "{{ user_groups[group] }}"
-
-- name: Run update-ssh-keys
-  become: False
-  command: update-ssh-keys -l
-  no_log: True
+  notify:
+    - update authorized_keys

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,14 +5,14 @@
   when: "{{ exclusive }}"
   changed_when: False
 
-- name: Delete keys for user {{ item }}
+- name: Delete keys for non-existing users
   file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
   when: exclusive and item not in user_groups[group]
   with_items: "{{ keys.stdout_lines }}"
   notify:
     - update authorized_keys
 
-- name: Add keys for user {{ item }}
+- name: Synchronize keys for users
   become: False
   authorized_key:
     user: core


### PR DESCRIPTION
Quick fix for 2 bugs in `authorized_keys.d`:
- keys were being always deleted (and reinserted later), which had the correct overall behaviour but is more “accident prone”;
- `update-ssh-keys` was being called even when no change was done.
