### PR TITLE
tasks/main.yml: Fix issues running while in `--check` mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,18 @@
-- name: List keys
-  become: False
-  command: ls -1 /home/core/.ssh/authorized_keys.d/
-  register: keys
-  check_mode: no
+- become: False
   when: "{{ exclusive }}"
-  changed_when: False
+  block:
+    - name: List keys
+      command: ls -1 /home/core/.ssh/authorized_keys.d/
+      register: keys
+      check_mode: no
+      changed_when: False
 
-- name: Delete keys for non-existing users
-  file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
-  when: exclusive and item not in user_groups[group]
-  with_items: "{{ keys.stdout_lines | default([]) }}"
-  notify:
-    - update authorized_keys
+    - name: Delete keys for non-existing users
+      file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
+      when: item not in user_groups[group]
+      with_items: "{{ keys.stdout_lines }}"
+      notify:
+        - update authorized_keys
 
 - name: Synchronize keys for users
   become: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,13 +2,14 @@
   become: False
   command: ls -1 /home/core/.ssh/authorized_keys.d/
   register: keys
+  always_run: yes
   when: "{{ exclusive }}"
   changed_when: False
 
 - name: Delete keys for non-existing users
   file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
   when: exclusive and item not in user_groups[group]
-  with_items: "{{ keys.stdout_lines }}"
+  with_items: "{{ keys.stdout_lines | default([]) }}"
   notify:
     - update authorized_keys
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
   become: False
   command: ls -1 /home/core/.ssh/authorized_keys.d/
   register: keys
-  always_run: yes
+  check_mode: no
   when: "{{ exclusive }}"
   changed_when: False
 


### PR DESCRIPTION
Some issues that arose:

- `check` mode disables the ability to use commands w/o `always_run` on.
- `with_items` is evaluated before `when`, meaning if the `ls` command
  isn't run, Ansible will give an error about `keys` not being valid.
  * A better solution to this would be to instead use the `find` module;
    however, as of right now, this will work.