### PR TITLE
Use `find` rather than ls-based hacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ correctly, by writing a user's keys to`~core/.ssh/authorized_keys.d/`
 and calling `update-ssh-keys` at the end.
 
 
-## Interface
+## Requirements
+
+The role uses Ansible's `find` module, which is available in the 2.x releases.
 
 The roles takes 2 parameters:
 - `exclusive` can be set to `yes` (defaults to `no`) to delete SSH keys

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,18 @@
-- name: List keys
-  become: False
-  command: ls -1 /home/core/.ssh/authorized_keys.d/
-  register: keys
-  check_mode: no
+- become: False
   when: "{{ exclusive }}"
-  changed_when: False
+  block:
+    - name: List keys
+      command: ls -1 /home/core/.ssh/authorized_keys.d/
+      register: keys
+      check_mode: no
+      changed_when: False
 
-- name: Delete keys for non-existing users
-  file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
-  when: exclusive and item not in user_groups[group]
-  with_items: "{{ keys.stdout_lines | default([]) }}"
-  notify:
-    - update authorized_keys
+    - name: Delete keys for non-existing users
+      file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
+      when: item not in user_groups[group]
+      with_items: "{{ keys.stdout_lines }}"
+      notify:
+        - update authorized_keys
 
 - name: Synchronize keys for users
   become: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,14 @@
   when: "{{ exclusive }}"
   block:
     - name: List keys
-      command: ls -1 /home/core/.ssh/authorized_keys.d/
+      find:
+        paths: /home/core/.ssh/authorized_keys.d/
       register: keys
-      check_mode: no
-      changed_when: False
 
     - name: Delete keys for non-existing users
       file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
       when: item not in user_groups[group]
-      with_items: "{{ keys.stdout_lines }}"
+      with_items: "{{ keys.files | map(attribute='path') | map('basename') | list }}"
       notify:
         - update authorized_keys
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,13 +2,14 @@
   become: False
   command: ls -1 /home/core/.ssh/authorized_keys.d/
   register: keys
+  always_run: yes
   when: "{{ exclusive }}"
   changed_when: False
 
 - name: Delete keys for non-existing users
   file: path=/home/core/.ssh/authorized_keys.d/{{ item }} state=absent
   when: exclusive and item not in user_groups[group]
-  with_items: "{{ keys.stdout_lines }}"
+  with_items: "{{ keys.stdout_lines | default([]) }}"
   notify:
     - update authorized_keys
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
   become: False
   command: ls -1 /home/core/.ssh/authorized_keys.d/
   register: keys
-  always_run: yes
+  check_mode: no
   when: "{{ exclusive }}"
   changed_when: False
 


### PR DESCRIPTION
Since admin-tools now require Ansible 2.x, this is fine.
Thanks to @RyanSquared for noticing this.

This PR piggy-backs on #8, so please wait for it to be merged before merging that one.