### PR TITLE
tasks: Do not explicitely template values in `when`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 - become: False
-  when: "{{ exclusive }}"
+  when: exclusive
   block:
     - name: List keys
       find:


### PR DESCRIPTION
This is a minor nit, but one that Ansible 2.4 warns about